### PR TITLE
fix(lint): remove explicit any usage via local types; safer error handling

### DIFF
--- a/src/app/api/mission/activity/update/route.ts
+++ b/src/app/api/mission/activity/update/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const record = await upsertItem('activity', body);
     return withCors(NextResponse.json({ ok: true, activity: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    return withCors(NextResponse.json({ ok: false, error: (e instanceof Error ? e.message : 'error') }, { status: 400 }));
   }
 }

--- a/src/app/api/mission/agents/upsert/route.ts
+++ b/src/app/api/mission/agents/upsert/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const record = await upsertItem('agents', body);
     return withCors(NextResponse.json({ ok: true, agent: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    return withCors(NextResponse.json({ ok: false, error: (e instanceof Error ? e.message : 'error') }, { status: 400 }));
   }
 }

--- a/src/app/api/mission/content/stage/route.ts
+++ b/src/app/api/mission/content/stage/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json(); // expects { id, status, ...optional }
     const record = await upsertItem('content', body);
     return withCors(NextResponse.json({ ok: true, content: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    return withCors(NextResponse.json({ ok: false, error: (e instanceof Error ? e.message : 'error') }, { status: 400 }));
   }
 }

--- a/src/app/api/mission/content/upsert/route.ts
+++ b/src/app/api/mission/content/upsert/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const record = await upsertItem('content', body);
     return withCors(NextResponse.json({ ok: true, content: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    return withCors(NextResponse.json({ ok: false, error: (e instanceof Error ? e.message : 'error') }, { status: 400 }));
   }
 }

--- a/src/app/api/mission/events/upsert/route.ts
+++ b/src/app/api/mission/events/upsert/route.ts
@@ -15,7 +15,8 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const record = await upsertItem('events', body);
     return withCors(NextResponse.json({ ok: true, event: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'error';
+    return withCors(NextResponse.json({ ok: false, error: msg }, { status: 400 }));
   }
 }

--- a/src/app/api/mission/memories/ingest/route.ts
+++ b/src/app/api/mission/memories/ingest/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const record = await upsertItem('memories', body);
     return withCors(NextResponse.json({ ok: true, memory: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    return withCors(NextResponse.json({ ok: false, error: (e instanceof Error ? e.message : 'error') }, { status: 400 }));
   }
 }

--- a/src/app/api/mission/subagents/upsert/route.ts
+++ b/src/app/api/mission/subagents/upsert/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const record = await upsertItem('subagents', body);
     return withCors(NextResponse.json({ ok: true, subagent: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    return withCors(NextResponse.json({ ok: false, error: (e instanceof Error ? e.message : 'error') }, { status: 400 }));
   }
 }

--- a/src/app/api/mission/tasks/patchStatus/route.ts
+++ b/src/app/api/mission/tasks/patchStatus/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
     if (!body?.id) throw new Error('id required');
     const record = await upsertItem('tasks', body);
     return withCors(NextResponse.json({ ok: true, task: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    return withCors(NextResponse.json({ ok: false, error: (e instanceof Error ? e.message : 'error') }, { status: 400 }));
   }
 }

--- a/src/app/api/mission/tasks/upsert/route.ts
+++ b/src/app/api/mission/tasks/upsert/route.ts
@@ -15,7 +15,8 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const record = await upsertItem('tasks', body);
     return withCors(NextResponse.json({ ok: true, task: record }));
-  } catch (e: any) {
-    return withCors(NextResponse.json({ ok: false, error: e?.message || 'error' }, { status: 400 }));
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'error';
+    return withCors(NextResponse.json({ ok: false, error: msg }, { status: 400 }));
   }
 }

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -24,12 +24,13 @@ export default async function CalendarPage(props: { searchParams?: Promise<{ m?:
     revalidatePath('/calendar');
   }
 
-  const events = await listItems<any>('events');
+  type CalEvent = { id: string; title?: string; when?: string; kind?: string };
+  const events = await listItems<CalEvent>('events');
   const sp = await props.searchParams;
   const m = sp?.m; // YYYY-MM
   const base = m && /^\d{4}-\d{2}$/.test(m) ? new Date(m + '-01T00:00:00Z') : new Date();
   const { month, year, cells } = buildMonthGrid(base);
-  const byDay: Record<string, any[]> = {};
+  const byDay: Record<string, CalEvent[]> = {};
   for (const e of events){
     const key = (e.when||'').slice(0,10);
     if (!byDay[key]) byDay[key] = []; byDay[key].push(e);
@@ -56,7 +57,7 @@ export default async function CalendarPage(props: { searchParams?: Promise<{ m?:
             <div key={i} className={`min-h-24 card p-2 ${inMonth?'':'opacity-50'}`}>
               <div className="text-[11px] muted">{d.getDate()}</div>
               <div className="mt-1 space-y-1">
-                {dayEvents.map((e:any)=> (
+                {dayEvents.map((e: CalEvent)=> (
                   <div key={e.id} className="rounded bg-slate-100 px-2 py-1">
                     <div className="text-xs font-medium">{e.title}</div>
                     <div className="text-[11px] text-slate-500">{fmtTime(e.when)} • {e.kind||'event'}</div>

--- a/src/app/content/page.tsx
+++ b/src/app/content/page.tsx
@@ -19,7 +19,8 @@ export default async function ContentPage() {
     revalidatePath('/content');
   }
 
-  const items = await listItems<any>('content');
+  import type { ContentItem } from '@/components/ContentBoard';
+  const items = await listItems<ContentItem>('content');
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold">Content Pipeline</h1>

--- a/src/app/memory/page.tsx
+++ b/src/app/memory/page.tsx
@@ -14,7 +14,8 @@ export default async function MemoryPage(props: { searchParams?: Promise<{ q?: s
     revalidatePath('/memory');
   }
 
-  const items = await listItems<any>('memories');
+  type MemoryItem = { id: string; title?: string; contentMarkdown?: string; tags?: string[] };
+  const items = await listItems<MemoryItem>('memories');
   const filtered = q ? items.filter(m => (m.title||'').toLowerCase().includes(q) || (m.contentMarkdown||'').toLowerCase().includes(q)) : items;
   return (
     <div className="space-y-4">

--- a/src/app/office/page.tsx
+++ b/src/app/office/page.tsx
@@ -12,7 +12,8 @@ export default async function OfficePage() {
     revalidatePath('/office');
   }
 
-  const activity = await listItems<any>('activity');
+  type Activity = { id: string; agentId?: string; status?: 'idle'|'working'|'blocked'; taskRef?: string };
+  const activity = await listItems<Activity>('activity');
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold">Office</h1>

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -22,7 +22,8 @@ export default async function TasksPage() {
     'use server';
     const id = String(formData.get('id') || '');
     const delta = Number(formData.get('delta') || 0);
-    const all = await listItems<any>('tasks');
+    import type { Task } from '@/components/TaskBoard';
+    const all = await listItems<Task>('tasks');
     const t = all.find(x=>x.id===id);
     if (!t) return;
     const col = t.status || 'todo';
@@ -39,7 +40,8 @@ export default async function TasksPage() {
     revalidatePath('/tasks');
   }
 
-  const tasks = await listItems<any>('tasks');
+  import type { Task } from '@/components/TaskBoard';
+  const tasks = await listItems<Task>('tasks');
   const cols = ['todo','doing','done','blocked'];
   return (
     <div className="space-y-4">

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -21,8 +21,10 @@ export default async function TeamPage() {
     revalidatePath('/team');
   }
 
-  const agents = await listItems<any>('agents');
-  const subs = await listItems<any>('subagents');
+  type Agent = { id: string; name?: string; role?: string; responsibilities?: string[] };
+  type Sub = { id: string; parentAgentId: string; name?: string; role?: string };
+  const agents = await listItems<Agent>('agents');
+  const subs = await listItems<Sub>('subagents');
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Team</h1>


### PR DESCRIPTION
- Calendar/Content/Tasks/Memory/Team/Office pages: define local types and use listItems<T>\n- API routes: catch (e: unknown) and safe message extraction\n- Keeps store loose but removes page-level \'any\' to satisfy lint